### PR TITLE
When creating new repomd.xml, respect umask setting.

### DIFF
--- a/lib/rpm2swidtag/repodata.py
+++ b/lib/rpm2swidtag/repodata.py
@@ -1,6 +1,6 @@
 
 from lxml import etree
-from os import path, stat, rename, unlink
+from os import path, stat, rename, unlink, umask, chmod
 from hashlib import sha256
 from io import BytesIO
 from gzip import GzipFile
@@ -49,6 +49,9 @@ class Repomd:
 	def save(self):
 		outpath = NamedTemporaryFile(dir=path.dirname(self.path), prefix="." + path.basename(self.path), delete=False)
 		self.xml.write(outpath.file, xml_declaration=True, encoding="utf-8", pretty_print=True)
+		orig_umask = umask(0)
+		umask(orig_umask)
+		chmod(outpath.name, 0o666 & ~orig_umask)
 		rename(outpath.name, self.path)
 
 class Primary:

--- a/test.sh
+++ b/test.sh
@@ -531,11 +531,15 @@ sleep 1.5
 touch tmp/repo/repodata/a-swidtags.xml.gz
 sleep 1.5
 touch tmp/repo/repodata/c-swidtags.xml.gz
+(
+umask 022
 $BIN/rpm2swidtag --repo=tmp/repo $RPM2SWIDTAG_OPTS --authoritative --tag-creator "example/test Example Org." --software-creator "other.test Other Org." --sign-pem=$SIGNDIR/test.key,$SIGNDIR/test-ca.crt,$SIGNDIR/test.crt --retain-old-md 2
+)
 zcat tmp/repo/repodata/???*-swidtags.xml.gz > tmp/repo/swidtags.xml
 diff tests/repodata-swidtags.xml tmp/repo/swidtags.xml
 
 test "$REPOMD_INODE" != "$( ls -i tmp/repo/repodata/repomd.xml )"
+ls -l tmp/repo/repodata/repomd.xml | grep '^-rw-r--r--'
 
 ( ! test -f tmp/repo/repodata/z-swidtags.xml.gz )
 test -f tmp/repo/repodata/a-swidtags.xml.gz


### PR DESCRIPTION
Amending 403eef94efbbc2ca785f33adeb2f224ac850e919.

Fixes https://github.com/swidtags/rpm2swidtag/issues/1.